### PR TITLE
Support building from PyPI

### DIFF
--- a/swmm-toolkit/pyproject.toml
+++ b/swmm-toolkit/pyproject.toml
@@ -1,0 +1,9 @@
+[build-system]
+requires = [
+    "wheel>=0.38.1",
+    "setuptools>=42",
+    "scikit-build>=0.13",
+    "cmake>=3.21",
+    "swig==4.0.2",
+]
+build-backend = "setuptools.build_meta"

--- a/swmm-toolkit/setup.py
+++ b/swmm-toolkit/setup.py
@@ -20,6 +20,13 @@ import os
 from skbuild import setup
 from setuptools import Command
 
+# hack to trick setuptools until we transition to scikit-build-core
+# without these libs, setuptools will fail to build sdist thinking the 
+# package is pure python and missing.
+_HERE_ = os.path.abspath(os.path.dirname(__file__))
+os.mkdir(os.path.join(_HERE_, 'bin'))
+os.mkdir(os.path.join(_HERE_, 'lib'))
+
 
 # Determine platform
 platform_system = platform.system()
@@ -88,7 +95,6 @@ def exclude_files(cmake_manifest):
 here = pathlib.Path(__file__).parent.resolve()
 long_description = (here / 'README.md').read_text(encoding='utf-8')
 
-
 setup(
     name = "swmm-toolkit",
     version = "0.14.2",
@@ -128,3 +134,8 @@ setup(
         "Development Status :: 5 - Production/Stable",
     ]
 )
+
+
+# clean up setuptools hack
+os.rmdir(os.path.join(_HERE_, 'bin'))
+os.rmdir(os.path.join(_HERE_, 'lib'))

--- a/swmm-toolkit/setup.py
+++ b/swmm-toolkit/setup.py
@@ -19,14 +19,7 @@ import pathlib
 import os
 from skbuild import setup
 from setuptools import Command
-
-# hack to trick setuptools until we transition to scikit-build-core
-# without these libs, setuptools will fail to build sdist thinking the 
-# package is pure python and missing.
-_HERE_ = os.path.abspath(os.path.dirname(__file__))
-os.mkdir(os.path.join(_HERE_, 'bin'))
-os.mkdir(os.path.join(_HERE_, 'lib'))
-
+import sys
 
 # Determine platform
 platform_system = platform.system()
@@ -63,11 +56,28 @@ class CleanCommand(Command):
         p.wait()
 
 
-# Set up location of wheel libraries depending on build platform
-if platform_system == "Windows":
-    package_dir = {"swmm_toolkit":"bin", "swmm.toolkit": "src/swmm/toolkit"}
+# Set up location of wheel libraries depending on build platform and command
+# commands that trigger cmake from skbuild.setuptools_wrap._should_run_cmake
+commands_that_trigger_cmake = {
+        "build",
+        "build_ext",
+        "develop",
+        "install",
+        "install_lib",
+        "bdist",
+        "bdist_dumb",
+        "bdist_egg",
+        "bdist_rpm",
+        "bdist_wininst",
+        "bdist_wheel",
+        "test",
+    }
+command = sys.argv[1] if len(sys.argv) > 1 else None
+if command in commands_that_trigger_cmake:
+    swmm_toolkit_dir= "bin" if platform_system == "Windows" else "lib"
 else:
-    package_dir = {"swmm_toolkit":"lib", "swmm.toolkit": "src/swmm/toolkit"}
+    swmm_toolkit_dir= "swmm-solver"
+package_dir = {"swmm_toolkit" : swmm_toolkit_dir, "swmm.toolkit": "src/swmm/toolkit"}
 
 
 if os.environ.get('SWMM_CMAKE_ARGS') is not None:
@@ -134,8 +144,3 @@ setup(
         "Development Status :: 5 - Production/Stable",
     ]
 )
-
-
-# clean up setuptools hack
-os.rmdir(os.path.join(_HERE_, 'bin'))
-os.rmdir(os.path.join(_HERE_, 'lib'))

--- a/swmm-toolkit/test-requirements.txt
+++ b/swmm-toolkit/test-requirements.txt
@@ -3,5 +3,5 @@
 
 pytest == 7.1.1
 numpy  == 1.21.6; python_version == "3.7"
-numpy  == 1.22.0; python_version >= "3.8"
+numpy  == 1.24.4; python_version >= "3.8"
 aenum  == 3.1.11


### PR DESCRIPTION
For the longest time, building this project from source required cloning from git, pulling the submodule, and running the setup.py script. 

Currently, if a user tries to pip install swmm-toolkit, and a wheel for their given version of python or system is not available on PyPI, pip tries to build from the source dist uploaded to PyPI and fails because the build tools are not installed. This PR attempts to resolve that problem by adding a pyproject.toml file that specifies the build backend and build tools.

In addition to the pyproject.toml, I had to add a small hack to the setup.py script to trick setuptools. I had to add this because scikit-build and setuptools don't play nice with `pip install .` or `python -m build`. When running code that generates the sdist or dist_info data, setuptools checks that packages are available. Since our package is only built when running cmake (from a different dir too), those package directories or not found because cmake is not run for sdist or dist_info, and the validation fails. Changing the setuptools package_dir parameter depending on if cmake is running gets around the issue, and I was able to run `pip install .` and `python -m build .` successfully in blank virtual envs.

Eventually it'd be nice to transition our build backend to [scikit-build-core](https://github.com/scikit-build/scikit-build-core), but I have not found a good way to make it work yet for multi-platform builds.