### PR TITLE
Fix MacOS OpenMP Linkage

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,10 +65,10 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_ARCHS_MACOS: x86_64
@@ -113,10 +113,10 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  
           # only build current supported python: https://devguide.python.org/versions/

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,9 +65,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
-            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
@@ -113,9 +113,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
-          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,7 +65,7 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
             export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
             DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,9 +65,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
+            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -3,12 +3,12 @@ name: Build Wheels
 # Cross compile wheels only on main branch and tags
 on:
   pull_request:
-    branches:    
-      - master  
-  push:
-    branches:    
+    branches:
       - master
-    tags:        
+  push:
+    branches:
+      - master
+    tags:
       - v*
   workflow_dispatch:
 
@@ -59,15 +59,15 @@ jobs:
         uses: pypa/cibuildwheel@v2.15.0
         with:
           package-dir: ./swmm-toolkit
-        env:          
+        env:
           CIBW_TEST_COMMAND: "pytest {package}/tests"
           CIBW_BEFORE_TEST: pip install -r {package}/test-requirements.txt
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
-          CIBW_ARCHS_WINDOWS: AMD64 
-          CIBW_ARCHS_MACOS: x86_64  
+          CIBW_ARCHS_WINDOWS: AMD64
+          CIBW_ARCHS_MACOS: x86_64
           # only build current supported python: https://devguide.python.org/versions/
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
@@ -75,6 +75,7 @@ jobs:
           # Will avoid testing on emulated architectures
           # Skip trying to test arm64 builds on Intel Macs
           CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
+          CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,10 +65,10 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
           CIBW_ARCHS_MACOS: x86_64
@@ -113,10 +113,10 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
-          # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  
           # only build current supported python: https://devguide.python.org/versions/

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,9 +65,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
@@ -113,9 +113,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,7 +65,7 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
             # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
             # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
@@ -113,9 +113,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
-            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
-            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          # CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+          #   export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
+          #   DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -44,7 +44,7 @@ jobs:
   build_wheels:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-2022, macos-12]
         pyver: [cp38, cp39, cp310, cp311]
@@ -88,7 +88,7 @@ jobs:
   build_cross_wheels:
     runs-on: ${{ matrix.os }}
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         os: [ubuntu-latest,macos-12]
         pyver: [cp38, cp39, cp310, cp311]

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -65,9 +65,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
@@ -113,9 +113,9 @@ jobs:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # need to pass the library path to delocate
-          CIBW_REPAIR_WHEEL_COMMAND_MACOS: ""
-            # export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
-            # DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src:$DYLD_LIBRARY_PATH" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -64,6 +64,10 @@ jobs:
           CIBW_BEFORE_TEST: pip install -r {package}/test-requirements.txt
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
+          # need to pass the library path to delocate
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
@@ -108,6 +112,10 @@ jobs:
         env:
           # mac needs ninja to build
           CIBW_BEFORE_BUILD_MACOS: brew install ninja
+          # need to pass the library path to delocate
+          CIBW_REPAIR_WHEEL_COMMAND_MACOS: >
+            export REPAIR_LIBRARY_PATH="$(cat ./swmm-toolkit/_skbuild/bindir)/_deps/openmp-build/runtime/src" &&
+            DYLD_LIBRARY_PATH=$REPAIR_LIBRARY_PATH delocate-wheel --require-archs {delocate_archs} -w {dest_dir} -v {wheel}
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  
@@ -115,6 +123,7 @@ jobs:
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
           CIBW_SKIP: cp36-* cp37-* cp312-* pp* *-musllinux*
+          CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v3
         with:

--- a/swmm-toolkit/CMakeLists.txt
+++ b/swmm-toolkit/CMakeLists.txt
@@ -36,10 +36,16 @@ cmake_policy(SET CMP0078 NEW)
 cmake_policy(SET CMP0086 NEW)
 include(${SWIG_USE_FILE})
 
-find_package(OpenMP
-    OPTIONAL_COMPONENTS
-        C
-)
+# If wheel build on Apple fetch and build OpenMP Library
+if (APPLE)
+    include(./extern/openmp.cmake)
+else()
+    find_package(OpenMP
+        REQUIRED
+        OPTIONAL_COMPONENTS
+            C
+    )
+endif()
 
 # Add project subdirectories
 add_subdirectory(swmm-solver)

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -50,13 +50,13 @@ install(TARGETS omp
 if(CMAKE_C_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
     set(OpenMP_C_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
+    set(OpenMP_omp_LIBRARY "${LIBRARY_DIST}/libomp.dylib")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
     set(OpenMP_CXX_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
+    set(OpenMP_omp_LIBRARY "${LIBRARY_DIST}/libomp.dylib")
 endif()
 
 # Save the bin directory for later use with

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -41,11 +41,11 @@ target_link_directories(omp
         $<INSTALL_INTERFACE:${LIBRARY_DIST}>
 )
 
-install(TARGETS omp
-    LIBRARY
-    DESTINATION
-        "${LIBRARY_DIST}"
-)
+# install(TARGETS omp
+#     LIBRARY
+#     DESTINATION
+#         "${LIBRARY_DIST}"
+# )
 
 if(CMAKE_C_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -50,13 +50,13 @@ install(TARGETS omp
 if(CMAKE_C_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
     set(OpenMP_C_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY "${LIBRARY_DIST}/libomp.dylib")
+    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
 endif()
 
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
     set(OpenMP_CXX_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY "${LIBRARY_DIST}/libomp.dylib")
+    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
 endif()
 
 # Save the bin directory for later use with

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -1,0 +1,52 @@
+#
+# CMakeLists.txt - CMake configuration file for OpenMP Library on Darwin
+#
+# Created: Mar 17, 2021
+# Updated: May 19, 2021
+#
+# Author: Michael E. Tryby
+#         US EPA ORD/CESER
+#
+# Note:
+#  Need to build libomp for binary compatibility with Python.
+#
+#  OpenMP library build fails for Xcode generator. Use Ninja or Unix Makefiles
+#  instead.
+#
+
+################################################################################
+#####################    CMAKELISTS FOR OPENMP LIBRARY    ######################
+################################################################################
+
+include(FetchContent)
+
+
+FetchContent_Declare(OpenMP
+    URL
+        https://github.com/llvm/llvm-project/releases/download/llvmorg-12.0.1/openmp-12.0.1.src.tar.xz
+    URL_HASH
+        SHA256=60fe79440eaa9ebf583a6ea7f81501310388c02754dbe7dc210776014d06b091
+)
+
+set(OPENMP_STANDALONE_BUILD TRUE)
+set(LIBOMP_INSTALL_ALIASES OFF)
+
+FetchContent_MakeAvailable(OpenMP)
+set(OpenMP_AVAILABLE TRUE)
+
+
+target_link_directories(omp
+    PUBLIC
+        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src>
+        $<INSTALL_INTERFACE:${LIBRARY_DIST}>
+)
+
+install(TARGETS omp
+    LIBRARY
+    DESTINATION
+        "${LIBRARY_DIST}"
+)
+
+# Save the bin directory for later use with
+# ci/cd build scripts
+file(WRITE _skbuild/bindir ${CMAKE_BINARY_DIR})

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -56,7 +56,7 @@ endif()
 if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
     set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
     set(OpenMP_CXX_LIB_NAMES "omp")
-    set(OpenMP_omp_LIBRARY "/usr/local/opt/libomp/lib/libomp.dylib")
+    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
 endif()
 
 # Save the bin directory for later use with

--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -47,6 +47,18 @@ install(TARGETS omp
         "${LIBRARY_DIST}"
 )
 
+if(CMAKE_C_COMPILER_ID MATCHES "Clang\$")
+    set(OpenMP_C_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
+    set(OpenMP_C_LIB_NAMES "omp")
+    set(OpenMP_omp_LIBRARY "${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src/libomp.dylib")
+endif()
+
+if(CMAKE_CXX_COMPILER_ID MATCHES "Clang\$")
+    set(OpenMP_CXX_FLAGS "-Xpreprocessor -fopenmp -I${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src")
+    set(OpenMP_CXX_LIB_NAMES "omp")
+    set(OpenMP_omp_LIBRARY "/usr/local/opt/libomp/lib/libomp.dylib")
+endif()
+
 # Save the bin directory for later use with
 # ci/cd build scripts
 file(WRITE _skbuild/bindir ${CMAKE_BINARY_DIR})


### PR DESCRIPTION
This PR corrects the bug introduced in the last release that resulted in [openmp not linking to MacOS builds](https://github.com/pyswmm/swmm-python/actions/runs/6111151545/job/16585745094#step:3:313). 

Furthermore, the cibuildwheel tool improves upon the old build methodology by bundling openmp library with the wheel.

[Check the wheel builds here](https://github.com/pyswmm/swmm-python/actions/runs/6113599736)
