### PR TITLE
add ninja to build requirements

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -106,8 +106,6 @@ jobs:
         with:
           package-dir: ./swmm-toolkit
         env:
-          # mac needs ninja to build
-          CIBW_BEFORE_BUILD_MACOS: brew install ninja
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones      
           CIBW_ARCHS_LINUX: aarch64
           CIBW_ARCHS_MACOS: arm64  

--- a/swmm-toolkit/CMakeLists.txt
+++ b/swmm-toolkit/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required (VERSION 3.17)
 
 project(swmm-toolkit
     VERSION
-        0.15.1
+        0.15.2
 )
 
 

--- a/swmm-toolkit/pyproject.toml
+++ b/swmm-toolkit/pyproject.toml
@@ -5,5 +5,6 @@ requires = [
     "scikit-build>=0.13",
     "cmake>=3.21",
     "swig==4.0.2",
+    "ninja==1.11.1 ; sys_platform == 'darwin'"
 ]
 build-backend = "setuptools.build_meta"

--- a/swmm-toolkit/setup.py
+++ b/swmm-toolkit/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name = "swmm-toolkit",
-    version = "0.15.1",
+    version = "0.15.2",
 
     packages = ["swmm_toolkit", "swmm.toolkit"],
     package_dir = package_dir,

--- a/swmm-toolkit/src/swmm/toolkit/__init__.py
+++ b/swmm-toolkit/src/swmm/toolkit/__init__.py
@@ -19,7 +19,7 @@ __copyright__ = "None"
 __credits__ = "Colleen Barr, Sam Hatchett"
 __license__ = "CC0 1.0 Universal"
 
-__version__ = "0.15.1"
+__version__ = "0.15.2"
 __date__ = "June 7, 2021"
 
 __maintainer__ = "Michael Tryby"


### PR DESCRIPTION
resolves install issues on macos when users don't have ninja installed at the system level