### PR TITLE
bump version to v0.15.5

### DIFF
--- a/swmm-toolkit/CMakeLists.txt
+++ b/swmm-toolkit/CMakeLists.txt
@@ -15,7 +15,7 @@ cmake_minimum_required (VERSION 3.17)
 
 project(swmm-toolkit
     VERSION
-        0.15.4
+        0.15.5
 )
 
 

--- a/swmm-toolkit/setup.py
+++ b/swmm-toolkit/setup.py
@@ -112,7 +112,7 @@ else:
 
 setup(
     name = "swmm-toolkit",
-    version = "0.15.4",
+    version = "0.15.5",
 
     packages = ["swmm_toolkit", "swmm.toolkit"],
     package_dir = package_dir,

--- a/swmm-toolkit/src/swmm/toolkit/__init__.py
+++ b/swmm-toolkit/src/swmm/toolkit/__init__.py
@@ -19,7 +19,7 @@ __copyright__ = "None"
 __credits__ = "Colleen Barr, Sam Hatchett"
 __license__ = "CC0 1.0 Universal"
 
-__version__ = "0.15.4"
+__version__ = "0.15.5"
 __date__ = "June 7, 2021"
 
 __maintainer__ = "Michael Tryby"


### PR DESCRIPTION
generate new wheel for v0.15.5 release that will have the swmm-solver library that was compiled with v0.15.3