### PR TITLE
Update series test for end period inclusive

### DIFF
--- a/swmm-toolkit/build-requirements.txt
+++ b/swmm-toolkit/build-requirements.txt
@@ -1,9 +1,8 @@
 
 
 
-setuptools   == 65.5.1
-wheel        == 0.38.1
-scikit-build == 0.11.1
-cmake        == 3.21
+setuptools
+wheel
+scikit-build
+cmake
 swig         == 4.0.2
-ninja; sys_platform == "darwin"

--- a/swmm-toolkit/tests/test_output.py
+++ b/swmm-toolkit/tests/test_output.py
@@ -96,11 +96,12 @@ def test_getsubcatchseries(handle):
                           0.040894926,
                           0.011605669,
                           0.00509294,
-                          0.0027438672])
+                          0.0027438672,
+                          0.0016718778])
 
     test_array = output.get_subcatch_series(handle, 1, shared_enum.SubcatchAttribute.RUNOFF_RATE, 0, 10)
 
-    assert len(test_array) == 10
+    assert len(test_array) == 11
     assert np.allclose(test_array, ref_array)
 
 


### PR DESCRIPTION
This pull request updates build requirements, synchronizes the solver submodule, and corrects a test case in the output module. The main changes focus on improving dependency management and ensuring test accuracy.

**Build requirements update:**
* Removed version pinning for `setuptools`, `wheel`, `scikit-build`, and `cmake` in `build-requirements.txt` to allow more flexible dependency versions.

**Submodule synchronization:**
* Updated the `swmm-solver` submodule to a newer commit, ensuring the latest solver code is used.

**Test corrections:**
* Fixed the `test_getsubcatchseries` test in `test_output.py` by updating the reference array and assertion to expect 11 values instead of 10, matching the actual output.