### PR TITLE
update swig

### DIFF
--- a/swmm-toolkit/build-requirements.txt
+++ b/swmm-toolkit/build-requirements.txt
@@ -5,4 +5,4 @@ setuptools
 wheel
 scikit-build
 cmake
-swig == 4.0.2
+swig

--- a/swmm-toolkit/pyproject.toml
+++ b/swmm-toolkit/pyproject.toml
@@ -4,7 +4,7 @@ requires = [
     "setuptools>=42",
     "scikit-build>=0.13",
     "cmake>=3.21",
-    "swig==4.0.2",
-    "ninja==1.11.1 ; sys_platform == 'darwin'"
+    "swig",
+    "ninja==1.11.1 ; sys_platform == 'darwin'",
 ]
 build-backend = "setuptools.build_meta"

--- a/swmm-toolkit/src/swmm/toolkit/output.i
+++ b/swmm-toolkit/src/swmm/toolkit/output.i
@@ -12,7 +12,6 @@
 %include "typemaps.i"
 %include "cstring.i"
 
-
 /* Docstrings for module */
 %include "output_docs.i"
 
@@ -28,6 +27,8 @@
 //%rename("%(regex:/^\w+_([a-zA-Z]+)/\L\\1/)s") "";
 %include "output_rename.i"
 
+/* SWIG Override headers*/
+%include "swig_headers.i"
 
 /* MARK FUNCTIONS FOR ALLOCATING AND DEALLOCATING HANDLES */
 %newobject SMO_init;
@@ -77,7 +78,7 @@ and return a (possibly) different pointer */
       for(int i=0; i<*$2; i++) {
         PyList_SetItem(o, i, PyFloat_FromDouble((double)temp[i]));
       }
-      $result = SWIG_Python_AppendOutput($result, o);
+      $result = SWIG_AppendOutput($result, o);
       SMO_freeMemory(*$1);
     }
 }
@@ -94,7 +95,7 @@ and return a (possibly) different pointer */
         for(int i=0; i<*$2; i++) {
             PyList_SetItem(o, i, PyInt_FromLong((long)temp[i]));
         }
-        $result = SWIG_Python_AppendOutput($result, o);
+        $result = SWIG_AppendOutput($result, o);
         SMO_freeMemory(*$1);
     }
 }

--- a/swmm-toolkit/src/swmm/toolkit/solver.i
+++ b/swmm-toolkit/src/swmm/toolkit/solver.i
@@ -31,6 +31,8 @@
 
 %include "stats_typemaps.i";
 
+/* SWIG Override headers*/
+%include "swig_headers.i"
 
 
 /* TYPEMAP FOR IGNORING INT ERROR CODE RETURN VALUE */
@@ -108,7 +110,7 @@
       for(int i=0; i<*$2; i++) {
         PyList_SetItem(o, i, PyFloat_FromDouble(temp$argnum[i]));
       }
-      $result = SWIG_Python_AppendOutput($result, o);
+      $result = SWIG_AppendOutput($result, o);
       swmm_freeMemory(*$1);
     }
 }

--- a/swmm-toolkit/src/swmm/toolkit/swig_headers.i
+++ b/swmm-toolkit/src/swmm/toolkit/swig_headers.i
@@ -1,0 +1,38 @@
+
+/* 
+in version 4.3, swig had a breaking change. Python functions that return None 
+no longer implicitly return void. see https://github.com/swig/swig/pull/2907
+and https://github.com/swig/swig/issues/2905
+
+This header block reverts the change from that commit, since I cannot find a 
+more concise way to implicitly make functions that return None just be void.
+
+I think the "correct" way is to define typemap(outs) that match every function
+signature we have and drop the error code accordingly.
+*/
+%header %{
+SWIGINTERN PyObject*
+Custom_SWIG_Python_AppendOutput(PyObject* result, PyObject* obj, int is_void) {
+    if (!result) {
+    result = obj;
+    } else if (result == Py_None) {
+    SWIG_Py_DECREF(result);
+    result = obj;
+    } else {
+    if (!PyList_Check(result)) {
+        PyObject *o2 = result;
+        result = PyList_New(1);
+        if (result) {
+        PyList_SET_ITEM(result, 0, o2);
+        } else {
+        SWIG_Py_DECREF(obj);
+        return o2;
+        }
+    }
+    PyList_Append(result,obj);
+    SWIG_Py_DECREF(obj);
+    }
+    return result;
+}
+#define SWIG_Python_AppendOutput Custom_SWIG_Python_AppendOutput
+%}


### PR DESCRIPTION
This pull request includes updates to support using newer versions of swig. As time marches on, it gets more difficult to rely on older versions of software build tools like swig. We currently depend on 4.0.2 since more recent versions are not compatible with our configuration. 

The main addition in this PR is a [monkey patch to swig](https://github.com/karosc/swmm-python/blob/9030d7f599b40933059bd7152b829d4ab4824a9f/swmm-toolkit/src/swmm/toolkit/swig_headers.i) that reverts a breaking change for us made in 4.3. Also, calls to `SWIG_Python_AppendOutput` have been replaced with `SWIG_AppendOutput` per the recommendation in the [swig release notes on 2024-10-05](https://www.swig.org/Release/CHANGES)