### PR TITLE
Dev wheel build

### DIFF
--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -41,7 +41,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ${{ steps.get_wheel.outputs.artifact_name }}
+          path: ./${{ steps.get_wheel.outputs.artifact_name }}
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -35,12 +35,13 @@ jobs:
             python setup.py bdist_wheel
 
       - name: Get wheel filename
-        run: echo "artifact_name=$(ls dist/*.whl | xargs -n1 basename)" >> $GITHUB_OUTPUT
+        id: get_wheel 
+        run: echo "artifact_name=$( ls dist/*.whl )" >> $GITHUB_OUTPUT
     
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          path: dist/${{ steps.get_wheel.outputs.artifact_name }}
+          path: ${{ steps.get_wheel.outputs.artifact_name }}
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -82,6 +82,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
+          name: wheels-${{ matrix.os }}-${{ matrix.py }}
           path: ./wheelhouse/*.whl
 
   build_cross_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -60,6 +60,7 @@ jobs:
         with:
           package-dir: ./swmm-toolkit
         env:
+          MACOSX_DEPLOYMENT_TARGET: 11.0
           CIBW_TEST_COMMAND: "pytest {package}/tests"
           CIBW_BEFORE_TEST: pip install -r {package}/test-requirements.txt
           # mac needs ninja to build
@@ -74,7 +75,7 @@ jobs:
           # only build current supported python: https://devguide.python.org/versions/
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
-          CIBW_SKIP: cp36-* cp37-* pp* *-musllinux*
+          CIBW_SKIP: cp38-* pp* *-musllinux*
           # Will avoid testing on emulated architectures
           # Skip trying to test arm64 builds on Intel Macs
           CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -40,7 +40,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          path: dist/${{ steps.get_wheel.outputs.artifact_name }}.whl
+          path: dist/${{ steps.get_wheel.outputs.artifact_name }}
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -40,8 +40,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.get_wheel.outputs.artifact_name }}
-          path: dist/*.whl
+          path: dist/${{ steps.get_wheel.outputs.artifact_name }}.whl
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -38,12 +38,13 @@ jobs:
         id: get_wheel 
         run: |
             echo "PWD=$PWD"
-            echo "artifact_name=$( ls dist/*.whl )" >> $GITHUB_OUTPUT
+            echo "artifact_name=$( ls dist/*.whl | xargs -n1 basename )" >> $GITHUB_OUTPUT
     
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          path: $PWD/${{ steps.get_wheel.outputs.artifact_name }}
+          name: name: ${{ steps.get_wheel.outputs.artifact_name }}
+          path: dist/*.whl
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -22,14 +22,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
-        with:
-          submodules: true
+        uses: actions/checkout@v5
 
       - name: Install Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
-          python-version: 3.10
+          python-version: '3.10'
 
       - name: Build wheel
         run: |

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -37,7 +37,6 @@ jobs:
       - name: Get wheel filename
         id: get_wheel 
         run: |
-            echo "PWD=$PWD"
             echo "artifact_name=$( ls dist/*.whl | xargs -n1 basename )" >> $GITHUB_OUTPUT
     
       - name: Upload wheel artifact

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -33,16 +33,11 @@ jobs:
         run: |
             pip install wheel
             python setup.py bdist_wheel
-
-      - name: Get wheel filename
-        id: get_wheel 
-        run: |
-            echo "artifact_name=$( ls dist/*.whl | xargs -n1 basename )" >> $GITHUB_OUTPUT
     
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ steps.get_wheel.outputs.artifact_name }}
+          name: nrtest-swmm-wheel
           path: nrtest-swmm/dist/*.whl
   
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -47,7 +47,7 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        pyver: [cp39, cp310, cp311, cp312]
+        pyver: [cp39, cp310, cp311, cp312, cp313]
 
     steps:
       - name: Checkout repo
@@ -91,7 +91,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        pyver: [cp38, cp39, cp310, cp311, cp312]
+        pyver: [cp39, cp310, cp311, cp312, cp313]
 
     steps:
       - name: Checkout repo

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -87,16 +87,15 @@ jobs:
           path: ./wheelhouse/*.whl
 
   build_cross_wheels:
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest,macos-12]
         pyver: [cp38, cp39, cp310, cp311, cp312]
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v3
+        uses: actions/checkout@v5
         with:
             submodules: true
 
@@ -116,13 +115,13 @@ jobs:
           CIBW_BEFORE_BUILD_LINUX: rm -f $(which swig) && rm -f $(which swig4.0)
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones
           CIBW_ARCHS_LINUX: aarch64
-          CIBW_ARCHS_MACOS: arm64
           # only build current supported python: https://devguide.python.org/versions/
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
-          CIBW_SKIP: cp36-* cp37-* cp-*38 pp* *-musllinux*
+          CIBW_SKIP: cp-*38 pp* *-musllinux*
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4
         with:
+          name:  wheels-linux-aarch64-${{ matrix.pyver }}
           path: ./wheelhouse/*.whl

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -33,11 +33,16 @@ jobs:
         run: |
             pip install wheel
             python setup.py bdist_wheel
-      - uses: actions/upload-artifact@v4
+
+      - name: Get wheel filename
+        run: echo "artifact_name=$(ls dist/*.whl | xargs -n1 basename)" >> $GITHUB_OUTPUT
+    
+      - name: Upload wheel artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: nrtest-swmm/dist/*.whl
-
-
+          name: ${{ steps.get_wheel.outputs.artifact_name }}
+          path: dist/*.whl
+  
 
   build_wheels:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -36,12 +36,14 @@ jobs:
 
       - name: Get wheel filename
         id: get_wheel 
-        run: echo "artifact_name=$( ls dist/*.whl )" >> $GITHUB_OUTPUT
+        run: |
+            echo "PWD=$PWD"
+            echo "artifact_name=$( ls dist/*.whl )" >> $GITHUB_OUTPUT
     
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          path: ./${{ steps.get_wheel.outputs.artifact_name }}
+          path: $PWD/${{ steps.get_wheel.outputs.artifact_name }}
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -71,14 +71,14 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_ARCHS_MACOS: x86_64
+          CIBW_ARCHS_MACOS: arm64
           # only build current supported python: https://devguide.python.org/versions/
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
           CIBW_SKIP: cp38-* pp* *-musllinux*
           # Will avoid testing on emulated architectures
           # Skip trying to test arm64 builds on Intel Macs
-          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_arm64 *-macosx_universal2:arm64"
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_x86_64 *-macosx_universal2:arm64"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -43,7 +43,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.get_wheel.outputs.artifact_name }}
-          path: dist/*.whl
+          path: nrtest-swmm/dist/*.whl
   
 
   build_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -71,14 +71,14 @@ jobs:
           # configure cibuildwheel to build native archs ('auto'), and some emulated ones
           CIBW_ARCHS_LINUX: x86_64
           CIBW_ARCHS_WINDOWS: AMD64
-          CIBW_ARCHS_MACOS: arm64
+          CIBW_ARCHS_MACOS: x86_64 arm64
           # only build current supported python: https://devguide.python.org/versions/
           # don't build pypy or musllinux to save build time. TODO: find a good way to support those archs
           CIBW_BUILD: ${{matrix.pyver}}-*
           CIBW_SKIP: cp38-* pp* *-musllinux*
           # Will avoid testing on emulated architectures
           # Skip trying to test arm64 builds on Intel Macs
-          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_x86_64 *-macosx_universal2:arm64"
+          CIBW_TEST_SKIP: "*-*linux_{aarch64,ppc64le,s390x} *-macosx_universal2:arm64"
           CIBW_BUILD_VERBOSITY: 1
 
       - uses: actions/upload-artifact@v4

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload wheel artifact
         uses: actions/upload-artifact@v4
         with:
-          name: name: ${{ steps.get_wheel.outputs.artifact_name }}
+          name: ${{ steps.get_wheel.outputs.artifact_name }}
           path: dist/*.whl
   
 

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -82,7 +82,7 @@ jobs:
 
       - uses: actions/upload-artifact@v4
         with:
-          name: wheels-${{ matrix.os }}-${{ matrix.py }}
+          name: wheels-${{ matrix.os }}-${{ matrix.pyver }}
           path: ./wheelhouse/*.whl
 
   build_cross_wheels:

--- a/.github/workflows/build_wheel.yml
+++ b/.github/workflows/build_wheel.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           package-dir: ./swmm-toolkit
         env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
           CIBW_TEST_COMMAND: "pytest {package}/tests"
           CIBW_BEFORE_TEST: pip install -r {package}/test-requirements.txt
           # mac needs ninja to build

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -45,7 +45,7 @@ jobs:
 
       - name: Build wheel in virtual env
         env:
-          MACOSX_DEPLOYMENT_TARGET: 11.0
+          MACOSX_DEPLOYMENT_TARGET: "11.0"
         run: |
           python -m venv --clear ./build-env
           ${{matrix.activate}}

--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -44,6 +44,8 @@ jobs:
           python-version: "3.10"
 
       - name: Build wheel in virtual env
+        env:
+          MACOSX_DEPLOYMENT_TARGET: 11.0
         run: |
           python -m venv --clear ./build-env
           ${{matrix.activate}}

--- a/swmm-toolkit/setup.py
+++ b/swmm-toolkit/setup.py
@@ -88,7 +88,7 @@ elif platform_system == "Windows":
     cmake_args = ["-GVisual Studio 17 2022","-Ax64"]
 
 elif platform_system == "Darwin":
-    cmake_args = ["-GXcode","-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=11.0"]
+    cmake_args = ["-GXcode"]
 
 else:
     cmake_args = ["-GUnix Makefiles"]

--- a/swmm-toolkit/test-requirements.txt
+++ b/swmm-toolkit/test-requirements.txt
@@ -1,8 +1,8 @@
 
 
 
-pytest == 7.1.1
-numpy  == 1.21.6; python_version == "3.7"
-numpy  == 1.24.4; python_version < "3.12"
-numpy  == 1.26.2; python_version >= "3.12"
+pytest == 8.4.1
+numpy  == 2.0.2; python_version < "3.10"
+numpy  == 2.2.6; python_version == "3.10.*"
+numpy  == 2.3.2; python_version >= "3.11"
 aenum  == 3.1.11


### PR DESCRIPTION
This pull request updates the build and test workflows for the project to improve compatibility with newer Python versions and macOS, streamline artifact naming, and adjust architecture support. The most significant changes include updating GitHub Actions versions, expanding Python and architecture coverage, and setting the macOS deployment target for builds and tests.

**Workflow and Compatibility Updates:**

* Upgraded GitHub Actions for checkout and Python setup to use `actions/checkout@v5` and `actions/setup-python@v5` for improved reliability and future compatibility.
* Added support for Python 3.13 in the build matrix for both native and cross-platform wheel builds, and removed Python 3.8 from builds to align with current supported versions. [[1]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6L25-R50) [[2]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6L73-R98)
* Expanded macOS wheel builds to include both `x86_64` and `arm64` architectures, improving support for Apple Silicon.
* Set `MACOSX_DEPLOYMENT_TARGET` to `"11.0"` in both wheel build and unit test workflows to ensure compatibility with newer macOS environments. [[1]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6R63) [[2]](diffhunk://#diff-012d76a293bfa67c5d65f938b15705520eef288139f3b513cd16266e6f780a4cR47-R48)

**Artifact and Build Process Improvements:**

* Standardized artifact naming for wheel uploads to include OS and Python version, making it easier to identify and retrieve build outputs. [[1]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6L25-R50) [[2]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6L73-R98) [[3]](diffhunk://#diff-1bfb94625879c066adc69f9157d41b4222554759abc52ca8854e117321b726f6L117-R126)
* Removed explicit setting of `CMAKE_OSX_DEPLOYMENT_TARGET` in the macOS build configuration in `setup.py`, relying on environment variables instead for consistency across workflows.