### PR TITLE
fix openmp linking on macos

### DIFF
--- a/swmm-toolkit/extern/openmp.cmake
+++ b/swmm-toolkit/extern/openmp.cmake
@@ -65,6 +65,18 @@ FetchContent_MakeAvailable(
     OpenMP
 )
 
+set(OpenMP_AVAILABLE TRUE)
+
+set(OPENMP_INCLUDE_DIR
+    ${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src
+)
+
+target_include_directories(
+    omp
+    INTERFACE
+        ${OPENMP_INCLUDE_DIR}
+)
+
 target_compile_options(
   omp
     INTERFACE
@@ -75,7 +87,7 @@ target_compile_options(
 target_link_directories(
   omp
     PUBLIC
-        $<BUILD_INTERFACE:${CMAKE_BINARY_DIR}/_deps/openmp-build/runtime/src>
+        $<BUILD_INTERFACE:${OPENMP_INCLUDE_DIR}>
         $<INSTALL_INTERFACE:/include>
 )
 


### PR DESCRIPTION
This fixes a regression that prevents openmp from linking on macos

Adding `set(OpenMP_AVAILABLE TRUE)` gets swmm-solver to attempt linking to omp project built on macos

Adding the target_include_directories block below gets swmm-solver to find omp.h when compiling. 
```
target_include_directories(
    omp
    INTERFACE
        ${OPENMP_INCLUDE_DIR}
)
```