### PR TITLE
fix(toolkit): populate Python3_SOABI from sysconfig when empty

### DIFF
--- a/.github/workflows/unit_test.yml
+++ b/.github/workflows/unit_test.yml
@@ -58,3 +58,17 @@ jobs:
           pip install -r test-requirements.txt
           pip install --no-index --find-links=./dist swmm_toolkit
           pytest
+
+      # Regression test for the Python3_SOABI fallback. Builds with
+      # NO_STABLE_ABI=1 and runs the ctest suffix guardrail to catch the
+      # double-dot filename bug (e.g. _solver..so) that occurs when
+      # CMake's FindPython3 fails to populate Python3_SOABI.
+      - name: Build + ctest (NO_STABLE_ABI path)
+        shell: bash
+        env:
+          NO_STABLE_ABI: "1"
+        run: |
+          pip install cmake swig
+          cmake -S . -B build_cmake
+          cmake --build build_cmake --config Release
+          ctest --test-dir build_cmake --output-on-failure -C Release

--- a/swmm-toolkit/CMakeLists.txt
+++ b/swmm-toolkit/CMakeLists.txt
@@ -36,6 +36,8 @@ cmake_policy(SET CMP0078 NEW)
 cmake_policy(SET CMP0086 NEW)
 include(${SWIG_USE_FILE})
 
+enable_testing()
+
 # Add project subdirectories
 add_subdirectory(swmm-solver)
 

--- a/swmm-toolkit/src/swmm/toolkit/CMakeLists.txt
+++ b/swmm-toolkit/src/swmm/toolkit/CMakeLists.txt
@@ -28,6 +28,14 @@ set(PY_LIMITED_API_DEF "Py_LIMITED_API=0x03090000")
 string(TOLOWER "$ENV{NO_STABLE_ABI}" _abi_val)
 if(_abi_val STREQUAL "1" OR _abi_val STREQUAL "true")
     set(PY_LIMITED_API_DEF "")
+    if(NOT Python3_SOABI)
+        execute_process(
+            COMMAND ${Python3_EXECUTABLE} -c
+                "import sysconfig; print(sysconfig.get_config_var('SOABI') or '')"
+            OUTPUT_VARIABLE Python3_SOABI
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+        )
+    endif()
     set(SOABI ".${Python3_SOABI}")
 endif()
 
@@ -187,6 +195,31 @@ install(
         "${PYTHON_INSTALL_DIR}"
     COMPONENT python
 )
+
+#############################################################
+####################    SUFFIX TESTS     ####################
+#############################################################
+
+# Verify that each extension module was linked with a valid Python ABI suffix.
+# Guards against the double-dot bug (_solver..so) that occurs when
+# CMake's FindPython3 fails to populate Python3_SOABI.
+# Run with: cmake --build <build_dir> && ctest --test-dir <build_dir>
+
+foreach(_ext_target output solver)
+    add_test(
+        NAME ExtensionSuffix_${_ext_target}
+        COMMAND ${Python3_EXECUTABLE} -c
+            "import importlib.machinery, os; \
+p = r'$<TARGET_FILE:${_ext_target}>'; \
+valid = importlib.machinery.EXTENSION_SUFFIXES; \
+assert os.path.exists(p), f'Extension not found: {p!r}'; \
+assert '..' not in os.path.basename(p), \
+    f'Double-dot ABI bug in {p!r} -- Python3_SOABI was empty at configure time'; \
+assert any(p.endswith(s) for s in valid), \
+    f'Invalid suffix in {p!r}, expected one of {valid}'; \
+print('PASS:', p)"
+    )
+endforeach()
 
 # Copy libomp.dylib on macOS if using scikit-build-core
 if(APPLE AND DEFINED SKBUILD_PLATLIB_DIR)


### PR DESCRIPTION
## Summary

Fixes the double-dot extension filename (e.g. `_solver..so`, `_output..so`) produced when `NO_STABLE_ABI=1` is set and CMake's `FindPython3` fails to populate `Python3_SOABI`. The malformed suffix makes the compiled modules unimportable, which is the likely root cause of [#155](https://github.com/pyswmm/swmm-python/issues/155).

The build does `set(SOABI ".${Python3_SOABI}")`, so an empty `Python3_SOABI` collapses the suffix to a single `.` and the linker emits `_solver..so`.

## What this PR does

1. **Fallback:** in `swmm-toolkit/src/swmm/toolkit/CMakeLists.txt`, when `Python3_SOABI` is empty under the `NO_STABLE_ABI` branch, query the interpreter for `sysconfig.get_config_var('SOABI')` and use that. This is the canonical source of the ABI tag.
2. **Guardrail:** add two ctest tests (`ExtensionSuffix_output`, `ExtensionSuffix_solver`) that assert each built module exists, has no `..` in its basename, and ends with a valid `importlib.machinery.EXTENSION_SUFFIXES` entry. `enable_testing()` is added at the project root to support this.
3. **CI regression coverage:** add a step to `unit_test.yml` that performs a direct CMake build with `NO_STABLE_ABI=1` and runs `ctest` on Linux, macOS, and Windows. The existing wheel test only covers the default stable-ABI path, so without this step the fallback has no CI coverage.

## Verification (local, macOS arm64, Python 3.14)

| Config | Extension filenames | ctest |
|---|---|---|
| `NO_STABLE_ABI=1` | `_output.cpython-314-darwin.so`, `_solver.cpython-314-darwin.so` | 2/2 pass |
| Default (stable ABI) | `_output.abi3.so`, `_solver.abi3.so` | 2/2 pass |
| Synthetic `_solver..so` | n/a | Guardrail correctly fails with `Double-dot ABI bug` |

## Test plan

- [x] Local build + ctest with `NO_STABLE_ABI=1`
- [x] Local build + ctest with default (stable ABI)
- [x] Local negative test proving the guardrail catches a double-dot filename
- [ ] CI: `Unit Test` workflow passes on Ubuntu, macOS, Windows (including the new regression step)

Refs #155